### PR TITLE
No C++ when not needed

### DIFF
--- a/Codec/DemoasicFrames.c
+++ b/Codec/DemoasicFrames.c
@@ -155,7 +155,7 @@ void FastSharpeningBlurVW13A( short *Aptr,
 #define DEBAYER5x5		1
 #define CF_ENHANCE		1	//CineForm Enhancement Debayer
 
-inline void REDCELL(unsigned short *rgbptr, unsigned short *bayerptr, int width)
+void REDCELL(unsigned short *rgbptr, unsigned short *bayerptr, int width)
 {
 	int r,g,b;
 	{/* normal 5x5 */
@@ -201,7 +201,7 @@ inline void REDCELL(unsigned short *rgbptr, unsigned short *bayerptr, int width)
 	*rgbptr++ = SATURATE16(b);
 }
 
-inline void GRNREDCELL(unsigned short *rgbptr, unsigned short *bayerptr, int width)
+void GRNREDCELL(unsigned short *rgbptr, unsigned short *bayerptr, int width)
 {
 	int r,g,b;
 	{/* normal 5x5 */
@@ -248,7 +248,7 @@ inline void GRNREDCELL(unsigned short *rgbptr, unsigned short *bayerptr, int wid
 
 
 
-inline void GRNBLUCELL(unsigned short *rgbptr, unsigned short *bayerptr, int width)
+void GRNBLUCELL(unsigned short *rgbptr, unsigned short *bayerptr, int width)
 {
 	int r,g,b;
 	{/* normal 5x5 */
@@ -296,7 +296,7 @@ inline void GRNBLUCELL(unsigned short *rgbptr, unsigned short *bayerptr, int wid
 }
 
 
-inline void BLUCELL(unsigned short *rgbptr, unsigned short *bayerptr, int width)
+void BLUCELL(unsigned short *rgbptr, unsigned short *bayerptr, int width)
 {
 	int r,g,b;
 	{/* normal 5x5 */

--- a/Codec/lutpath.c
+++ b/Codec/lutpath.c
@@ -1,4 +1,4 @@
-/*! @file lutpath.h
+/*! @file lutpath.c
 
 *  @brief Active MetadataTools
 *
@@ -23,7 +23,6 @@
 #include "stdafx.h"
 #include "config.h"
 #include "encoder.h"
-#include <string>
 
 #ifdef _WINDOWS
 // Must include the following file for Visual Studio 2005 (not required for Visual Studio 2003)
@@ -147,18 +146,19 @@ FILE *OpenUserPrefsFile(char *actual_pathname, size_t actual_size)
 	if (home_dir)
 	{
 		// Initialize the preferences path with the user home directory
-		std::string pathname(home_dir);
-		pathname.append("/.cineform/dbsettings");
+		char pathname[PATH_MAX];
+		strncpy(pathname, home_dir, PATH_MAX);
+		strncat(pathname, "/.cineform/dbsettings", PATH_MAX);
 
 		// Does the user have a preferences file?
-		FILE *file = fopen(pathname.c_str(), "r");
+		FILE *file = fopen(pathname, "r");
 		if (file)
 		{
 			if (actual_pathname)
 			{
 				// Return the actual preferences pathname for error messages
 				int actual_length = actual_size / sizeof(actual_pathname[0]);
-				strncpy(actual_pathname, pathname.c_str(), actual_length);
+				strncpy(actual_pathname, pathname, actual_length);
 				actual_pathname[actual_length - 1] = '\0';
 			}
 			return file;
@@ -780,7 +780,7 @@ void InitLUTPathsEnc(ENCODER *encoder)
 		strncpy(encoder->UserDBPathStr, DATABASE_PATH_STRING, STRING_LENGTH(encoder->UserDBPathStr));
 
 		//FILE *file = fopen(SETTINGS_PATH_STRING, "r");
-		FILE *file = OpenUserPrefsFile();
+		FILE *file = OpenUserPrefsFile(NULL, 0);
 		if(file)
 		{
 			//TODO: Parse the encoder preferences file

--- a/Codec/lutpath.h
+++ b/Codec/lutpath.h
@@ -78,20 +78,12 @@ CODEC_ERROR ParseUserMetadataPrefs(FILE *file,
 
 #endif
 
+FILE *OpenUserPrefsFile(char *actual_pathname,			//!< Return the actual pathname
+                        size_t actual_size				//!< Return the pathname size (in bytes)
+                        );
+
 #ifdef __cplusplus
 }
 #endif
 
 
-#ifdef __cplusplus
-
-extern "C"
-FILE *OpenUserPrefsFile(char *actual_pathname = NULL,	//!< Return the actual pathname
-						size_t actual_size = 0			//!< Return the pathname size (in bytes)
-						);
-#else
-
-FILE *OpenUserPrefsFile(char *actual_pathname,			//!< Return the actual pathname
-						size_t actual_size				//!< Return the pathname size (in bytes)
-						);
-#endif

--- a/Common/CFHDDecoder.h
+++ b/Common/CFHDDecoder.h
@@ -29,8 +29,7 @@
 #include "CFHDError.h"
 #include "CFHDTypes.h"
 #include "CFHDMetadata.h"
-#ifdef _QTZPATCH
-#else
+#ifdef __cplusplus
 #include "CFHDSampleHeader.h"
 #endif
 


### PR DESCRIPTION
The first patch ("Cpp include is not required and must be header guarded") is the only one really needed, because it prevent using the CineForm SDK being used in a C program.
The other two are just here because they are C++ files without C++, so why not leave them be builded as the other file from the Codec/ directory? I can split the pull request if you need.