### PR TITLE
WIP: buildsystem with OS integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,73 +1,112 @@
-# CMakeLists.txt
 cmake_minimum_required (VERSION 3.5.1)
 project (CineFormSDK)
 
-set(LINK_STATIC OFF)
+
+# Build settings
+set(BUILD_CODECSDK ON)
+set(BUILD_TOOLS ON)
+set(BUILD_TOOLS_STATIC OFF)
+
+set(CMAKE_CONFIGURATION_TYPES "Debug;Release")
+add_definitions(-D_ALLOCATOR=1 -DWARPSTUFF=1)
 
 if (WIN32)
 	include(ucm.cmake)
 	ucm_set_runtime(STATIC)
-	
-	SET(COMPILER_FLAGS "")
-	SET(COMPILER_FLAGS_W_OMP "/openmp" )
-	SET(ADDITIONAL_LIBS "")
+
+	set(COMPILER_FLAGS "")
+	set(COMPILER_FLAGS_W_OMP "/openmp" )
+	set(ADDITIONAL_LIBS "")
 endif (WIN32)
- 
+
 if (UNIX)
-	SET(COMPILER_FLAGS -fPIC -O3)
-	SET(COMPILER_FLAGS_W_OMP -fopenmp -O3)
-	SET(ADDITIONAL_LIBS "-luuid -lpthread -lgomp")
-	SET(TOY_LIBS "-lm")
+	set(COMPILER_FLAGS -fPIC -O3)
+	set(COMPILER_FLAGS_W_OMP -fopenmp -O3)
+	set(ADDITIONAL_LIBS "-luuid -lpthread -lgomp")
+	set(TOY_LIBS "-lm")
 endif (UNIX)
 
 if (APPLE)
-	SET(COMPILER_FLAGS -fvisibility=hidden -O3)
-	SET(COMPILER_FLAGS_W_OMP -O3)
-	SET(ADDITIONAL_LIBS "-lpthread")
+	set(COMPILER_FLAGS -fvisibility=hidden -O3)
+	set(COMPILER_FLAGS_W_OMP -O3)
+	set(ADDITIONAL_LIBS "-lpthread")
 endif (APPLE)
 
-set(CMAKE_CONFIGURATION_TYPES "Debug;Release")
 
+# Source files
 include_directories("Common" "Tables" "Codec" "ConvertLib" "WarpLib" "Example")
+file(GLOB PUBLIC_HEADERS "Common/CFHDAllocator.h Common/CFHDDecoder.h Common/CFHDEncoder.h  Common/CFHDError.h Common/CFHDMetadata.h Common/CFHDMetadataTags.h Common/CFHDSampleHeader.h Common/CFHDTypes.h")
 file(GLOB CODEC_SOURCES "Codec/*.c" "Codec/*.cpp" "WarpLib/*.c" "Common/Settings.cpp")
 file(GLOB ENCODER_ALL_SOURCES "Codec/*.c" "Codec/*.cpp" "Common/Settings.cpp" "EncoderSDK/*.cpp")
 file(GLOB DECODER_ALL_SOURCES "Codec/*.c" "Codec/*.cpp" "Common/Settings.cpp"  "ConvertLib/*.cpp" "WarpLib/*.c" "DecoderSDK/*.cpp")
 file(GLOB ENCODER_SOURCES "EncoderSDK/*.cpp")
-file(GLOB DECODER_SOURCES "DecoderSDK/*.cpp" "WarpLib/*.c" "ConvertLib/*.cpp" )
-file(GLOB EXAMPLE_SOURCE "Example/*.cpp" )
-file(GLOB WAVELETDEMO_SOURCE "Example/WaveletDemo/*.c" )
+file(GLOB DECODER_SOURCES "DecoderSDK/*.cpp" "WarpLib/*.c" "ConvertLib/*.cpp")
+file(GLOB EXAMPLE_SOURCE "Example/*.cpp")
+file(GLOB WAVELETDEMO_SOURCE "Example/WaveletDemo/*.c")
 
-add_definitions(-D_ALLOCATOR=1 -DWARPSTUFF=1)
 
-add_library(CodecSDK ${CODEC_SOURCES})
+# Build CFHDEncoder and CFHDDecoder libraries
 add_library(CFHDEncoderStatic ${ENCODER_ALL_SOURCES})
 add_library(CFHDDecoderStatic ${DECODER_ALL_SOURCES})
 add_library(CFHDEncoder SHARED ${ENCODER_SOURCES})
 add_library(CFHDDecoder SHARED ${DECODER_SOURCES})
 
-set_target_properties(CodecSDK PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(CFHDEncoder PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(CFHDDecoder PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-target_compile_options(CodecSDK PUBLIC ${COMPILER_FLAGS})
 target_compile_options(CFHDEncoder PUBLIC ${COMPILER_FLAGS})
 target_compile_options(CFHDDecoder PUBLIC ${COMPILER_FLAGS})
 target_compile_definitions(CFHDEncoder PUBLIC -DDYNAMICLIB=1)
 target_compile_definitions(CFHDDecoder PUBLIC -DDYNAMICLIB=1)
 
-target_link_libraries (CFHDEncoder CodecSDK)
-target_link_libraries (CFHDDecoder CodecSDK)
-target_link_libraries (CFHDEncoderStatic)
-target_link_libraries (CFHDDecoderStatic)
+target_link_libraries(CFHDEncoderStatic)
+target_link_libraries(CFHDDecoderStatic)
 
-add_executable (TestCFHD ${EXAMPLE_SOURCE})
-target_compile_options(TestCFHD PRIVATE ${COMPILER_FLAGS_W_OMP})
 
-if (LINK_STATIC)
-target_link_libraries (TestCFHD CFHDEncoderStatic CFHDDecoderStatic ${ADDITIONAL_LIBS})
-target_link_libraries (TestCFHD CFHDEncoderStatic CFHDDecoderStatic ${ADDITIONAL_LIBS})
-else (LINK_STATIC)
-target_link_libraries (TestCFHD CFHDEncoder CFHDDecoder ${ADDITIONAL_LIBS})
-target_link_libraries (TestCFHD CFHDEncoder CFHDDecoder ${ADDITIONAL_LIBS})
-endif (LINK_STATIC)
+# Build CodecSDK library
+if (BUILD_CODECSDK)
+	add_library(CodecSDK ${CODEC_SOURCES})
+	set_target_properties(CodecSDK PROPERTIES POSITION_INDEPENDENT_CODE ON)
+	target_compile_options(CodecSDK PUBLIC ${COMPILER_FLAGS})
+	target_link_libraries (CFHDEncoder CodecSDK)
+	target_link_libraries (CFHDDecoder CodecSDK)
+endif (BUILD_CODECSDK)
 
-add_executable (WaveletDemo ${WAVELETDEMO_SOURCE})
-target_link_libraries (WaveletDemo ${TOY_LIBS})
+
+# Build tools
+if (BUILD_TOOLS)
+	# TestCFHD
+	add_executable(TestCFHD ${EXAMPLE_SOURCE})
+	target_compile_options(TestCFHD PRIVATE ${COMPILER_FLAGS_W_OMP})
+
+	if (BUILD_TOOLS_STATIC)
+		target_link_libraries(TestCFHD CFHDEncoderStatic CFHDDecoderStatic ${ADDITIONAL_LIBS})
+		target_link_libraries(TestCFHD CFHDEncoderStatic CFHDDecoderStatic ${ADDITIONAL_LIBS})
+	else (BUILD_TOOLS_STATIC)
+		target_link_libraries(TestCFHD CFHDEncoder CFHDDecoder ${ADDITIONAL_LIBS})
+		target_link_libraries(TestCFHD CFHDEncoder CFHDDecoder ${ADDITIONAL_LIBS})
+	endif (BUILD_TOOLS_STATIC)
+
+	# WaveletDemo
+	add_executable(WaveletDemo ${WAVELETDEMO_SOURCE})
+	target_link_libraries(WaveletDemo ${TOY_LIBS})
+endif (BUILD_TOOLS)
+
+
+# Pkgconfig integration
+set(PROJECT_VERSION "10.0.2")
+set(LIB_SUFFIX "" CACHE STRING "Define suffix of directory name (32/64)")
+set(EXEC_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX} CACHE PATH "Installation prefix for executables and object code libraries" FORCE)
+set(BIN_INSTALL_DIR ${EXEC_INSTALL_PREFIX}/bin CACHE PATH "Installation prefix for user executables" FORCE)
+set(LIB_INSTALL_DIR ${EXEC_INSTALL_PREFIX}/lib${LIB_SUFFIX} CACHE PATH  "Installation prefix for object code libraries" FORCE)
+set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/include/cineformsdk CACHE PATH "Installation prefix for header files" FORCE)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libcineformsdk.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/libcineformsdk.pc)
+
+
+# System wide installation
+if (UNIX)
+	install(TARGETS CFHDDecoder DESTINATION lib/)
+	install(TARGETS CFHDEncoder DESTINATION lib/)
+	install(FILES libcineformsdk.pc DESTINATION lib/pkgconfig/)
+	install(FILES ${PUBLIC_HEADERS} DESTINATION include/cineformsdk/)
+endif (UNIX)

--- a/libcineformsdk.pc.cmake
+++ b/libcineformsdk.pc.cmake
@@ -1,0 +1,11 @@
+prefix=${CMAKE_INSTALL_PREFIX}
+exec_prefix=${EXEC_INSTALL_PREFIX}
+libdir=${LIB_INSTALL_DIR}
+includedir=${INCLUDE_INSTALL_DIR}
+
+Name: ${PROJECT_NAME}
+Description: CineForm SDK libraries
+URL: https://github.com/gopro/cineform-sdk
+Version: ${PROJECT_VERSION}
+Libs: -L${LIB_INSTALL_DIR} -lCFHDDecoder -lCFHDEncoder -lm
+Cflags: -I${INCLUDE_INSTALL_DIR}


### PR DESCRIPTION
Hi,
This work in progress patch add a few things to the CMake build system.

First, it introduce options that we can override at build time (well more configure time really) so we can disable things we don't need in particular cases (like BUILD_CODECSDK or BUILD_TOOLS). We can probably modularize it more if needed.

Second, this patch adds an installation step to the build system, so we can have a clean installation into macOS and every other unix systems. Right now it install public headers into PREFIX/include/cineformsdk and libraries into PREFIX/lib).
That allows me to integrate this repository, unpatched, into other build systems like VLC, GStreamer and ffmpeg.
Also, it allows me to produce macOS brew / whatever linux distributions packages in 3 simples commands: "cmake . & make & make install". Without patching the buildsystem and so without particular maintenance.

Finally, it adds a pkgconfig file, so we can integrate the CineForm SDK (if it has been installaled into a system) into various softwares very easily, just include the libcineformsdk.pc file and it will take care of include directories and link options automatically.
Note: I can create a similar .cmake file so we just need to do an "FIND_PACKAGE(CineFormSDK REQUIRED)" and... that's it.