### PR TITLE
CFHDSampleHeader.h contains a C++ class, and should only be included …

### DIFF
--- a/Common/CFHDDecoder.h
+++ b/Common/CFHDDecoder.h
@@ -27,8 +27,7 @@
 #include "CFHDError.h"
 #include "CFHDTypes.h"
 #include "CFHDMetadata.h"
-#ifdef _QTZPATCH
-#else
+#ifdef __cplusplus
 #include "CFHDSampleHeader.h"
 #endif
 


### PR DESCRIPTION
…with C++ builds