### PR TITLE
Add stdbool header for strict C builds

### DIFF
--- a/Common/CFHDTypes.h
+++ b/Common/CFHDTypes.h
@@ -24,6 +24,7 @@
 
 #include "CFHDAllocator.h"
 #include <stdint.h>
+#include <stdbool.h>
 #include <string.h>
 
 // Convert the four character code to the correct byte order


### PR DESCRIPTION
This is needed because depending on the C version used by default by a compiler (particularly with conservative settings like C99 I guess) it might complain about not knowing about the bool type.