### PR TITLE
Fix hang due to missing condition vaiable wake

### DIFF
--- a/EncoderSDK/EncoderQueue.h
+++ b/EncoderSDK/EncoderQueue.h
@@ -345,6 +345,7 @@ public:
 
 		// Increase the amount of space in the encoder job queue
 		available++;
+		space.Wake();
 
 		// Return the encoder job with the next encoded sample
 		return job;
@@ -364,6 +365,7 @@ public:
 
 		// Increase the amount of space in the encoder job queue
 		available++;
+		space.Wake();
 
 		// Return the encoder job with the next encoded sample
 		return job;


### PR DESCRIPTION
Hi,

The condition variable 'space' in EncoderQueue.h is never woken up.

Because of this the wait on EncoderQueue.h:318 blocks forever. This probably only happens on platforms that use the pthread implementation of ConditionVariable, because the other implementations seem to have a timeout.