### PR TITLE
Update ImageScaler.cpp

### DIFF
--- a/ConvertLib/ImageScaler.cpp
+++ b/ConvertLib/ImageScaler.cpp
@@ -85,13 +85,6 @@
 
 #include "cpuid.h"
 
-int GetProcessorCount()
-{
-	SYSTEM_INFO cSystem_info;
-	GetSystemInfo(&cSystem_info);
-	return cSystem_info.dwNumberOfProcessors;
-}
-
 #elif __APPLE__
 
 #include <sys/types.h>


### PR DESCRIPTION
Fix Windows build (remove duplicate GetProcessorCount, it was just changed from a static declaration in the header to an inline definition, but it is already defined in cpuid.c)