### PR TITLE
cmake policy CMP0004 gives error for whitespace in linker libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ if (OPENMP_FOUND)
 	add_definitions(-DHAVE_OPENMP=1)
 	SET(ADDITIONAL_LIBS "${ADDITIONAL_LIBS} ${OpenMP_CXX_FLAGS}")
 endif (OPENMP_FOUND)
+string(STRIP ${ADDITIONAL_LIBS} ADDITIONAL_LIBS)
 
 include_directories("Common" "Tables" "Codec" "ConvertLib" "WarpLib" "Example")
 file(GLOB CODEC_SOURCES "Codec/*.c" "Codec/*.h" "Codec/*.cpp" "WarpLib/*.c" "WarpLib/*.h" )


### PR DESCRIPTION
https://cmake.org/cmake/help/latest/policy/CMP0004.html